### PR TITLE
permite maior flexibilidade na ocultação do botão 'Laravel tools Dashboard'

### DIFF
--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -24,7 +24,7 @@ class EventServiceProvider extends ServiceProvider
                         'text' => '<i class="fas fa-toolbox text-danger"></i>',
                         'url' => route('laravel-tools.app'),
                         'title' => 'Laravel tools Dashboard',
-                        'can' => 'admin',
+                        'can' => ($event->item['can'] ?? 'admin'),
                     ];
                 }
                 return $event->item;


### PR DESCRIPTION
Com esta pequena alteração, permito aos clientes do laravel-tools ocultarem o botão 'Laravel tools Dashboard' em mais casos.

Antes disso, o botão ficava visível para admins.

Com a alteração, permito que o botão seja exibido somente se o admin estiver com o perfil admin.

Observação: eu já havia realizado esta mesma modificação no laravel-usp-theme, para os dois ícones vermelhos de administração do laravel-usp-theme. Por completude, estou fazendo também neste "terceiro ícone de administração" que fica aqui, no laravel-tools.