### PR TITLE
aplica hightlight no ícone do Laravel tools Dashboard

### DIFF
--- a/src/Http/Controllers/LogViewerController.php
+++ b/src/Http/Controllers/LogViewerController.php
@@ -17,9 +17,7 @@ class LogViewerController extends BaseController
 
     public function index()
     {
-        if (hasUspTheme()) {
-            \UspTheme::activeUrl(route('laravel-tools.app'));
-        }
+        \UspTheme::activeUrl(route('laravel-tools.app'));
         return parent::index();
     }
 }

--- a/src/Http/Controllers/LogViewerController.php
+++ b/src/Http/Controllers/LogViewerController.php
@@ -14,4 +14,12 @@ class LogViewerController extends BaseController
         $this->view_log = 'laravel-tools::log';
         parent::__construct();
     }
+
+    public function index()
+    {
+        if (hasUspTheme()) {
+            \UspTheme::activeUrl(route('laravel-tools.app'));
+        }
+        return parent::index();
+    }
 }

--- a/src/Http/Controllers/MainController.php
+++ b/src/Http/Controllers/MainController.php
@@ -23,6 +23,9 @@ class MainController extends Controller
      */
     public function app(Request $request)
     {
+        if (hasUspTheme()) {
+            \UspTheme::activeUrl(route('laravel-tools.app'));
+        }
         $request->validate([
             'tab' => 'nullable|string',
             'file' => 'nullable|string',
@@ -48,6 +51,9 @@ class MainController extends Controller
      */
     public function bibliotecas(Request $request)
     {
+        if (hasUspTheme()) {
+            \UspTheme::activeUrl(route('laravel-tools.app'));
+        }
         $request->validate([
             'tab' => 'nullable|string',
             'file' => 'nullable|string',
@@ -74,6 +80,9 @@ class MainController extends Controller
      */
     public static function backup(Request $request)
     {
+        if (hasUspTheme()) {
+            \UspTheme::activeUrl(route('laravel-tools.app'));
+        }
         $request->validate([
             'tab' => 'nullable|string',
             'file' => 'nullable|string',

--- a/src/Http/Controllers/MainController.php
+++ b/src/Http/Controllers/MainController.php
@@ -23,9 +23,7 @@ class MainController extends Controller
      */
     public function app(Request $request)
     {
-        if (hasUspTheme()) {
-            \UspTheme::activeUrl(route('laravel-tools.app'));
-        }
+        \UspTheme::activeUrl(route('laravel-tools.app'));
         $request->validate([
             'tab' => 'nullable|string',
             'file' => 'nullable|string',
@@ -51,9 +49,7 @@ class MainController extends Controller
      */
     public function bibliotecas(Request $request)
     {
-        if (hasUspTheme()) {
-            \UspTheme::activeUrl(route('laravel-tools.app'));
-        }
+        \UspTheme::activeUrl(route('laravel-tools.app'));
         $request->validate([
             'tab' => 'nullable|string',
             'file' => 'nullable|string',
@@ -80,9 +76,7 @@ class MainController extends Controller
      */
     public static function backup(Request $request)
     {
-        if (hasUspTheme()) {
-            \UspTheme::activeUrl(route('laravel-tools.app'));
-        }
+        \UspTheme::activeUrl(route('laravel-tools.app'));
         $request->validate([
             'tab' => 'nullable|string',
             'file' => 'nullable|string',


### PR DESCRIPTION
O ícone do Laravel tools Dashboard no menu da direita não ficava com highlight quando era carregada qualquer página do dashboard.

Com esta alteração, ele recebe o highlight, e fica com comportamento igual ao resto do menu, inclusive aos outros dois ícones vermelhos de admin (que não estão no laravel-tools mas no senhaunica-socialite).