### PR TITLE
corrige erro ao abrir o Laravel tools Dashboard em desenvolvimento

### DIFF
--- a/config/laravel-tools.php
+++ b/config/laravel-tools.php
@@ -15,4 +15,9 @@ return [
 
     // template a ser estendido. Deve possuir a section "content"
     'template' => 'laravel-usp-theme::master',
+
+    // as variáveis do $_SERVER não ficam disponíveis em desenvolvimento, pois o php artisan serve não lê o .htaccess, somente o apache o faz
+    // então as definimos aqui, para não dar erro no Laravel tools Dashboard em desenvolvimento
+    'gatewayInterface' => isset($_SERVER['GATEWAY_INTERFACE']) ? $_SERVER['GATEWAY_INTERFACE'] : '',
+    'serverSoftware' => isset($_SERVER['SERVER_SOFTWARE']) ? $_SERVER['SERVER_SOFTWARE'] : '',
 ];

--- a/resources/views/tabs/app.blade.php
+++ b/resources/views/tabs/app.blade.php
@@ -13,9 +13,9 @@
     <li>Config está em cache: <b>{{ app()->configurationIsCached() ? 'true' : 'false' }}</b></li>
     <li>Route está em cache: <b>{{ app()->routesAreCached() ? 'true' : 'false' }}</b></li>
     <li>Versão PHP: <b>{{ phpversion() }}</b></li>
-    <li>Gateway interface: <b>{{ $_SERVER['GATEWAY_INTERFACE'] }}</b></li>
+    <li>Gateway interface: <b>{{ config('laravel-tools.gatewayInterface') }}</b></li>
     <li>Extensões PHP: <b>{{ implode(', ', get_loaded_extensions()) }}</b></li>
-    <li>Versão Servidor: <b>{{ $_SERVER['SERVER_SOFTWARE'] }}</b></li>
+    <li>Versão Servidor: <b>{{ config('laravel-tools.serverSoftware') }}</b></li>
   </ul>
 </div>
 


### PR DESCRIPTION
Nos sistemas clientes do laravel-tools, ao clicar no ícone "Laravel tools Dashboard" do menu, em desenvolvimento ocorria erro, pois o php artisan serve não lê o .htaccess, e assim ficava sem ter definido o array $_SERVER. Já em produção, o apache lê esse arquivo e conseguia carregar a página.

Esta alteração faz com que o config/laravel-tools.php verifique o valor do $_SERVER e o carregue (em existindo). E então a view app.blade.php acessa essas variáveis do config.